### PR TITLE
WIP: Overhaul conversion operator computation + fix Weighted ldiv

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SemiclassicalOrthogonalPolynomials"
 uuid = "291c01f3-23f6-4eb6-aeb0-063a639b53f2"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.3.5"
+version = "0.4.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
@@ -21,7 +21,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [compat]
 ArrayLayouts = "1"
 BandedMatrices = "0.17"
-ClassicalOrthogonalPolynomials = "0.9, 0.10"
+ClassicalOrthogonalPolynomials = "0.10.1"
 ContinuumArrays = "0.12, 0.13"
 FillArrays = "1"
 HypergeometricFunctions = "0.3.4"
@@ -29,7 +29,7 @@ InfiniteArrays = "0.12.9"
 InfiniteLinearAlgebra = "0.6.19"
 LazyArrays = "1"
 QuasiArrays = "0.9, 0.10"
-SingularIntegrals = "0.0.2"
+SingularIntegrals = "0.1"
 SpecialFunctions = "1.0, 2"
 julia = "1.9"
 

--- a/src/neg1c.jl
+++ b/src/neg1c.jl
@@ -4,7 +4,10 @@
 ######
 
 # compute n-th coefficient from direct evaluation formula
-αdirect(n, t::T) where T = 2*n*_₂F₁((one(T)+n)/2,(n+2)/2,(2*n+3)/2,1/t^2)/(t*2*(1+2*n)*_₂F₁(n/2,(n+one(T))/2,(2*n+one(T))/2,1/t^2))
+function αdirect(n, tt::T) where T
+    t = big(tt)
+    return convert(T,2*n*_₂F₁((one(T)+n)/2,(n+2)/2,(2*n+3)/2,1/t^2)/(t*2*(1+2*n)*_₂F₁(n/2,(n+one(T))/2,(2*n+one(T))/2,1/t^2)))
+end
 
 # inital value n=0 for α_{n,n-1}(t) coefficients
 initialα(t) = t-2/(log1p(t)-log(t-1))


### PR DESCRIPTION
@ioannisPApapadopoulos @dlfivefifty  This PR fixes the issue https://github.com/JuliaApproximation/SemiclassicalOrthogonalPolynomials.jl/issues/78 with some caveats.

Roughly the issue was caused by Lanczos still being the backend for function expansion. Where applicable I have now replaced this with QR/Cholesky based expansions such that now the conversion operators are built up step by step too, i.e. if we do `P\Q` and `P` and `Q` are an integer parameter apart then the conversion is computed as `Rn*...*R3*R2*R1` instead of the direct way. This is a lot more stable but suffers immense time loss due to the lazy typing accumulation in the lazy products, I think related to https://github.com/JuliaArrays/LazyArrays.jl/issues/255

I will keep checking whether there is a way to speed this up but for low `c` it isn't any slower than Lanzos and for high `c` Lanczos fails completely as in your issue so this may simply end up being part of the cost.

Note that this requires ClassicalOPs.jl v0.10.1 which has not been registered yet.