### PR TITLE
Use contiguous recurrence for c-related sum computations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SemiclassicalOrthogonalPolynomials"
 uuid = "291c01f3-23f6-4eb6-aeb0-063a639b53f2"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
@@ -21,7 +21,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 ArrayLayouts = "1"
 BandedMatrices = "0.17"
 ClassicalOrthogonalPolynomials = "0.11"
-ContinuumArrays = "0.15"
+ContinuumArrays = "0.15, 0.16"
 FillArrays = "1"
 HypergeometricFunctions = "0.3.4"
 InfiniteArrays = "0.13"

--- a/src/SemiclassicalOrthogonalPolynomials.jl
+++ b/src/SemiclassicalOrthogonalPolynomials.jl
@@ -213,6 +213,7 @@ axes(P::SemiclassicalJacobi{T}) where T = (Inclusion(UnitInterval{T}()),OneToInf
 ==(A::SemiclassicalJacobi, B::SemiclassicalJacobi) = A.t == B.t && A.a == B.a && A.b == B.b && A.c == B.c
 ==(::AbstractQuasiMatrix, ::SemiclassicalJacobi) = false
 ==(::SemiclassicalJacobi, ::AbstractQuasiMatrix) = false
+==(::SemiclassicalJacobi, ::SubQuasiArray) = false
 
 orthogonalityweight(P::SemiclassicalJacobi) = SemiclassicalJacobiWeight(P.t, P.a, P.b, P.c)
 

--- a/src/SemiclassicalOrthogonalPolynomials.jl
+++ b/src/SemiclassicalOrthogonalPolynomials.jl
@@ -49,7 +49,7 @@ end
 
 function sum(P::SemiclassicalJacobiWeight{T}) where T
     (t,a,b,c) = (P.t, P.a, P.b, P.c)
-    t,a,b,c = BigFloat("$t"),BigFloat("$a"),BigFloat("$b"),BigFloat("$c") # This is needed at high parameter values
+    t,a,b,c = convert(BigFloat,t),convert(BigFloat,a),convert(BigFloat,b),convert(BigFloat,c) # This is needed at high parameter values
     return abs(convert(T, t^c*exp(loggamma(a+1)+loggamma(b+1)-loggamma(a+b+2)) * pFq((a+1,-c),(a+b+2, ), 1/t)))
 end
 
@@ -548,7 +548,7 @@ function Base.broadcasted(::typeof(sum), W::SemiclassicalJacobiCWeightFamily{T})
     @assert isinteger(cmax) && isinteger(cmin)
     # This is needed at high parameter values.
     # Manually setting setprecision(2048) allows accurate computation even for very high c. 
-    t,a,b = BigFloat("$t"),BigFloat("$a"),BigFloat("$b")
+    t,a,b = convert(BigFloat,t),convert(BigFloat,a),convert(BigFloat,b)
     sumw = (a,b,c,t) -> pFq((a+1,-c),(a+b+2, ), 1/t)
     F = zeros(BigFloat,cmax+1)
     F[1] = sumw(a,b,0,t) # c=0
@@ -566,7 +566,7 @@ function sumquotient(wP::SemiclassicalJacobiWeight{T},wQ::SemiclassicalJacobiWei
     @assert isinteger(wP.c) && isinteger(wQ.c)
     a = wP.a; b = wP.b; c = Int(wP.c); t = wP.t;
     # This is needed at high parameter values.
-    t,a,b = BigFloat("$t"),BigFloat("$a"),BigFloat("$b")
+    t,a,b = convert(BigFloat,t),convert(BigFloat,a),convert(BigFloat,b)
     sumw = (a,b,c,t) -> pFq((a+1,-c),(a+b+2, ), 1/t)
     F = zeros(BigFloat,max(2,c+1))
     F[1] = sumw(a,b,0,t) # c=0
@@ -575,7 +575,7 @@ function sumquotient(wP::SemiclassicalJacobiWeight{T},wQ::SemiclassicalJacobiWei
         F[n+2] = ((n-1)/t+1/t-n)/(n+a+b+2)*F[n]+(a+b+4+2*n-2-(n+a+1)/t)/(n+a+b+2)*F[n+1]
     end
     a = wQ.a; b = wQ.b; c = Int(wQ.c);
-    t,a,b = BigFloat("$t"),BigFloat("$a"),BigFloat("$b")
+    t,a,b = convert(BigFloat,t),convert(BigFloat,a),convert(BigFloat,b)
     G = zeros(BigFloat,max(2,c+1))
     G[1] = sumw(a,b,0,t) # c=0
     G[2] = sumw(a,b,1,t) # c=1

--- a/src/SemiclassicalOrthogonalPolynomials.jl
+++ b/src/SemiclassicalOrthogonalPolynomials.jl
@@ -348,7 +348,7 @@ function \(w_A::WeightedSemiclassicalJacobi, w_B::WeightedSemiclassicalJacobi)
     Δc = B.c-A.c
 
     if (wA.a == A.a) && (wA.b == A.b) && (wA.c == A.c) && (wB.a == B.a) && (wB.b == B.b) && (wB.c == B.c) && isinteger(A.a) && isinteger(A.b) && isinteger(A.c) && isinteger(B.a) && isinteger(B.b) && isinteger(B.c)
-        k = sum.(SemiclassicalJacobiWeight.(B.t,B.a,B.b,B.c:B.c))/sum.(SemiclassicalJacobiWeight(A.t,A.a,A.b,A.c:A.c)) # = (A \ SemiclassicalJacobiWeight(A.t,Δa,Δb,Δc))[1]
+        k = sum.(SemiclassicalJacobiWeight.(B.t,B.a,B.b,Int(B.c):Int(B.c)))[1]./sum.(SemiclassicalJacobiWeight.(A.t,A.a,A.b,Int(A.c):Int(A.c)))[1] # = (A \ SemiclassicalJacobiWeight(A.t,Δa,Δb,Δc))[1]
         return (ApplyArray(*,Diagonal(Fill(k,∞)),(B \ A)))'
     elseif wA.a == wB.a && wA.b == wB.b && wA.c == wB.c # fallback to Christoffel–Darboux
         A \ B
@@ -541,6 +541,7 @@ function Base.broadcasted(::typeof(sum), W::SemiclassicalJacobiCWeightFamily)
     cmax = maximum(c)
     F = zeros(cmax+1)
     F[1] = sumw(a,b,0,t) # c=0
+    cmax == 0 && return F[1:1]
     F[2] = sumw(a,b,1,t) # c=1
     for n in 1:cmax-1
         F[n+2] = (((b+1)*t-(a+1)*(1-t)+n*(2t-1))*F[n+1] + n*t*(1-t)*F[n-1+1])/(a+b+n+2)

--- a/src/SemiclassicalOrthogonalPolynomials.jl
+++ b/src/SemiclassicalOrthogonalPolynomials.jl
@@ -550,7 +550,7 @@ function Base.broadcasted(::typeof(sum), W::SemiclassicalJacobiCWeightFamily{T})
     sumw = (a,b,c,t) -> pFq((a+1,-c),(a+b+2, ), 1/t)
     F = zeros(BigFloat,cmax+1)
     F[1] = sumw(a,b,0,t) # c=0
-    cmax == 0 && return F[1:1]
+    cmax == 0 && return abs.(convert.(T,t.^c.*exp(loggamma(a+1)+loggamma(b+1)-loggamma(a+b+2)).*getindex(F,1:1)))
     F[2] = sumw(a,b,1,t) # c=1
     @inbounds for n in 1:cmax-1
         F[n+2] = ((n-1)/t+1/t-n)/(n+a+b+2)*F[n]+(a+b+4+2*n-2-(n+a+1)/t)/(n+a+b+2)*F[n+1]

--- a/src/SemiclassicalOrthogonalPolynomials.jl
+++ b/src/SemiclassicalOrthogonalPolynomials.jl
@@ -566,7 +566,7 @@ function sumquotient(wP::SemiclassicalJacobiWeight{T},wQ::SemiclassicalJacobiWei
     # This is needed at high parameter values.
     t,a,b = BigFloat("$t"),BigFloat("$a"),BigFloat("$b")
     sumw = (a,b,c,t) -> pFq((a+1,-c),(a+b+2, ), 1/t)
-    F = zeros(BigFloat,c+1)
+    F = zeros(BigFloat,max(2,c+1))
     F[1] = sumw(a,b,0,t) # c=0
     F[2] = sumw(a,b,1,t) # c=1
     @inbounds for n in 1:c-1
@@ -574,7 +574,7 @@ function sumquotient(wP::SemiclassicalJacobiWeight{T},wQ::SemiclassicalJacobiWei
     end
     a = wQ.a; b = wQ.b; c = Int(wQ.c);
     t,a,b = BigFloat("$t"),BigFloat("$a"),BigFloat("$b")
-    G = zeros(BigFloat,c+1)
+    G = zeros(BigFloat,max(2,c+1))
     G[1] = sumw(a,b,0,t) # c=0
     G[2] = sumw(a,b,1,t) # c=1
     @inbounds for n in 1:c-1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -354,8 +354,7 @@ end
     end
 
     @testset "conversion" begin
-        D = legendre(0..1) \ P
-        @test (P \ legendre(0..1))[1:10,1:10] == inv(Matrix(D[1:10,1:10]))
+        @test_broken (P \ legendre(0..1))[1:10,1:10] == inv(Matrix((legendre(0..1) \ P)[1:10,1:10]))
         @test_broken (P \ Weighted(P)) == (Weighted(P) \ P) == Eye(∞)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -604,6 +604,9 @@ end
         # c = 0
         t, a, b, c = 1.1, 1, 1, 0
         @test sum.(SemiclassicalJacobiWeight.(t,a,b,c:c))[1] ≈ t^c * beta(1+a,1+b) * _₂F₁(1+a,-c,2+a+b,1/t)
+        # c = 30
+        t, a, b, c = 1.23, 2, 3, 30
+        @test sum.(SemiclassicalJacobiWeight.(t,a,b,c:c))[1] ≈ t^c * beta(1+a,1+b) * _₂F₁(1+a,-c,2+a+b,1/t)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -586,5 +586,16 @@ end
     L'L
 end
 
+@testset "Contiguous computation of sums of weights" begin
+    # this computes it in the explicit way
+    Wcomp = SemiclassicalJacobiWeight.(1.1,2:2,3:3,3:100);
+    @time scomp = sum.(Wcomp);
+    # this uses the contiguous recurrence
+    W = SemiclassicalJacobiWeight.(1.1,2,3,3:100);
+    @time s = sum.(W);
+    # consistency
+    @test maximum(abs.(s - scomp)) ≤ 1e-15 
+end
+
 include("test_derivative.jl")
 include("test_neg1c.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using SemiclassicalOrthogonalPolynomials
-using ClassicalOrthogonalPolynomials, ContinuumArrays, BandedMatrices, QuasiArrays, Test, LazyArrays, FillArrays, LinearAlgebra
+using ClassicalOrthogonalPolynomials, ContinuumArrays, BandedMatrices, QuasiArrays, Test, LazyArrays, FillArrays, LinearAlgebra, SpecialFunctions, HypergeometricFunctions
 import BandedMatrices: _BandedMatrix
 import SemiclassicalOrthogonalPolynomials: op_lowering, RaisedOP, jacobiexpansion, semijacobi_ldiv_direct
 import ClassicalOrthogonalPolynomials: recurrencecoefficients, orthogonalityweight, symtridiagonalize
@@ -601,6 +601,9 @@ end
         @time s = sum.(W);
         # consistency
         @test maximum(abs.(s - scomp)) ≤ 1e-15 
+        # c = 0
+        t, a, b, c = 1.1, 1, 1, 0
+        @test sum.(SemiclassicalJacobiWeight.(t,a,b,c:c))[1] ≈ t^c * beta(1+a,1+b) * _₂F₁(1+a,-c,2+a+b,1/t)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -586,14 +586,22 @@ end
 end
 
 @testset "Contiguous computation of sums of weights" begin
-    # this computes it in the explicit way
-    Wcomp = SemiclassicalJacobiWeight.(1.1,2:2,3:3,3:100);
-    @time scomp = sum.(Wcomp);
-    # this uses the contiguous recurrence
-    W = SemiclassicalJacobiWeight.(1.1,2,3,3:100);
-    @time s = sum.(W);
-    # consistency
-    @test maximum(abs.(s - scomp)) ≤ 1e-15 
+    @testset "basics" begin
+        W = SemiclassicalJacobiWeight.(1.1,2,3,0:100)
+        @test W isa SemiclassicalOrthogonalPolynomials.SemiclassicalJacobiCWeightFamily
+        @test W[1] isa SemiclassicalJacobiWeight
+        @test size(W) == (101,)
+    end
+    @testset "consistency" begin
+        # this computes it in the explicit way
+        Wcomp = SemiclassicalJacobiWeight.(1.1,2:2,3:3,3:100);
+        @time scomp = sum.(Wcomp);
+        # this uses the contiguous recurrence
+        W = SemiclassicalJacobiWeight.(1.1,2,3,3:100);
+        @time s = sum.(W);
+        # consistency
+        @test maximum(abs.(s - scomp)) ≤ 1e-15 
+    end
 end
 
 include("test_derivative.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -354,7 +354,7 @@ end
     end
 
     @testset "conversion" begin
-        @test_broken (P \ legendre(0..1))[1:10,1:10] == inv(Matrix((legendre(0..1) \ P)[1:10,1:10]))
+        @test (P \ legendre(0..1))[1:10,1:10] == inv(Matrix((legendre(0..1) \ P)[1:10,1:10]))
         @test_broken (P \ Weighted(P)) == (Weighted(P) \ P) == Eye(∞)
     end
 end


### PR DESCRIPTION
@ioannisPApapadopoulos @dlfivefifty 

Basically just porting over @MikaelSlevinsky's contiguous recurrence implementation in a way that should be reasonably natural for this package. This should be both much faster and hopefully much more accurate at high c.

Previously we had
```julia
julia> Wcomp = SemiclassicalJacobiWeight.(1.1,2:2,3:3,3:100);

julia> @time scomp = sum.(Wcomp);
  0.112850 seconds (336.34 k allocations: 14.352 MiB)
```
Now we get
```julia
julia> W = SemiclassicalJacobiWeight.(1.1,2,3,3:100);

julia> @time s = sum.(W);
  0.000048 seconds (28 allocations: 2.156 KiB)
```
At no cost to accuracy (the old method using bigfloat, the new one just Float64):
```julia
julia> s - scomp
98-element Vector{Float64}:
 -2.6020852139652106e-18
 -2.6020852139652106e-18
 -1.734723475976807e-18
 -1.3010426069826053e-18
 -8.673617379884035e-19
  0.0
 -4.336808689942018e-19
 -2.168404344971009e-19
 -2.168404344971009e-19
  ⋮
  5.898059818321144e-17
  5.898059818321144e-17
  6.591949208711867e-17
  7.28583859910259e-17
  7.632783294297951e-17
  7.979727989493313e-17
  8.673617379884035e-17
  9.367506770274758e-17
  1.0408340855860843e-16
```

It's implemented to work whenever sum is broadcast over a crange vector of weights as seen above, as it is it wont be used if you just call sum on a single weight (mainly because doing that in a clean way would involve a lot of clauses about a, b and c and other contiguous recurrences), maybe we implement that at some point in the future. If you must use it on a single weight just do e.g. `sum.(SemiclassicalJacobiWeight.(1.1,2,3,3:3))`.

Still need to add and run tests.