### PR TITLE
Lowering connection cfs from raising connection cfs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1'
+          - '1.10'
         os:
           - ubuntu-latest
           - macOS-latest
@@ -28,12 +28,12 @@ jobs:
         arch:
           - x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
@@ -46,6 +46,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: lcov.info

--- a/src/SemiclassicalOrthogonalPolynomials.jl
+++ b/src/SemiclassicalOrthogonalPolynomials.jl
@@ -275,7 +275,7 @@ Returns conversion operator from SemiclassicalJacobi `P` to SemiclassicalJacobi 
 Numerically unstable if the parameter modification is large. Typically one should instead use `P \\ Q` which is equivalent to `semijacobi_ldiv(P,Q)` and proceeds step by step.
 """
 function semijacobi_ldiv_direct(Q::SemiclassicalJacobi, P::SemiclassicalJacobi)
-    (Q.t ≈ P.t) && (Q.a ≈ P.a) && (Q.b ≈ P.b) && (Q.c ≈ P.c) && return SymTridiagonal(Ones(∞),Zeros(∞))
+    (Q.t ≈ P.t) && (Q.a ≈ P.a) && (Q.b ≈ P.b) && (Q.c ≈ P.c) && return SquareEye{eltype(Q.t)}((axes(P,2),))
     Δa = Q.a-P.a
     Δb = Q.b-P.b
     Δc = Q.c-P.c
@@ -318,15 +318,15 @@ function semijacobi_ldiv_direct(Q::SemiclassicalJacobi, P::SemiclassicalJacobi)
     # special case (Δa,Δb,Δc) = (-1,0,0)
     elseif isone(-Δa) && iszero(Δb) && iszero(Δc)
         M = cholesky(Q.X).U
-        return ApplyArray(\, M, Diagonal(Fill(M[1],∞)))
+        return UpperTriangular(ApplyArray(inv,M/M[1]))
     # special case (Δa,Δb,Δc) = (0,-1,0)
     elseif iszero(Δa) && isone(-Δb) && iszero(Δc)
         M = cholesky(I-Q.X).U
-        return ApplyArray(\, M, Diagonal(Fill(M[1],∞)))
+        return UpperTriangular(ApplyArray(inv,M/M[1]))
     # special case (Δa,Δb,Δc) = (0,0,-1)
     elseif iszero(Δa) && iszero(Δb) && isone(-Δc)
         M = cholesky(Q.t*I-Q.X).U
-        return ApplyArray(\, M, Diagonal(Fill(M[1],∞)))
+        return UpperTriangular(ApplyArray(inv,M/M[1]))
     elseif isinteger(Δa) && isinteger(Δb) && isinteger(Δc) && (Δa ≥ 0) && (Δb ≥ 0) && (Δc ≥ 0)
         M = cholesky(Symmetric(P.X^(Δa)*(I-P.X)^(Δb)*(Q.t*I-P.X)^(Δc))).U
         return ApplyArray(*, Diagonal(Fill(1/M[1],∞)), M)
@@ -343,7 +343,7 @@ Returns conversion operator from SemiclassicalJacobi `P` to SemiclassicalJacobi 
 function semijacobi_ldiv(Q::SemiclassicalJacobi, P::SemiclassicalJacobi)
     @assert Q.t ≈ P.t
     T = promote_type(eltype(Q), eltype(P))
-    (Q.t ≈ P.t) && (Q.a ≈ P.a) && (Q.b ≈ P.b) && (Q.c ≈ P.c) && return SquareEye{T}(∞)
+    (Q.t ≈ P.t) && (Q.a ≈ P.a) && (Q.b ≈ P.b) && (Q.c ≈ P.c) && return return SquareEye{eltype(Q.t)}((axes(P,2),))
     Δa = Q.a-P.a
     Δb = Q.b-P.b
     Δc = Q.c-P.c

--- a/src/SemiclassicalOrthogonalPolynomials.jl
+++ b/src/SemiclassicalOrthogonalPolynomials.jl
@@ -342,7 +342,8 @@ Returns conversion operator from SemiclassicalJacobi `P` to SemiclassicalJacobi 
 """
 function semijacobi_ldiv(Q::SemiclassicalJacobi, P::SemiclassicalJacobi)
     @assert Q.t ≈ P.t
-    (Q.t ≈ P.t) && (Q.a ≈ P.a) && (Q.b ≈ P.b) && (Q.c ≈ P.c) && return SymTridiagonal(Ones(∞),Zeros(∞))
+    T = promote_type(eltype(Q), eltype(P))
+    (Q.t ≈ P.t) && (Q.a ≈ P.a) && (Q.b ≈ P.b) && (Q.c ≈ P.c) && return SquareEye{T}(∞)
     Δa = Q.a-P.a
     Δb = Q.b-P.b
     Δc = Q.c-P.c

--- a/src/SemiclassicalOrthogonalPolynomials.jl
+++ b/src/SemiclassicalOrthogonalPolynomials.jl
@@ -314,7 +314,7 @@ function semijacobi_ldiv_direct(Q::SemiclassicalJacobi, P::SemiclassicalJacobi)
     # special case (Δa,Δb,Δc) = (0,0,1)
     elseif iszero(Δa) && iszero(Δb) && isone(Δc)
         M = cholesky(Q.t*I-P.X).U
-        return ApplyArray(*, Diagonal(Fill(1/M[1],∞)), M)
+        return M/M[1]
     # special case (Δa,Δb,Δc) = (-1,0,0)
     elseif isone(-Δa) && iszero(Δb) && iszero(Δc)
         M = cholesky(Q.X).U

--- a/src/SemiclassicalOrthogonalPolynomials.jl
+++ b/src/SemiclassicalOrthogonalPolynomials.jl
@@ -294,23 +294,23 @@ function semijacobi_ldiv_direct(Q::SemiclassicalJacobi, P::SemiclassicalJacobi)
     # special case (Δa,Δb,Δc) = (-2,0,0)
     elseif (Δa == -2) && iszero(Δb) && iszero(Δc)
         M = qr(Q.X).R
-        return ApplyArray(\, M, Diagonal(sign.(view(M,band(0)))*abs.(M[1])))
+        return ApplyArray(\, M, Diagonal(sign.(view(M,band(0)))*abs(M[1])))
     # special case (Δa,Δb,Δc) = (0,-2,0)
     elseif iszero(Δa) && (Δb == -2) && iszero(Δc)
         M = qr(I-Q.X).R
-        return ApplyArray(\, M, Diagonal(sign.(view(M,band(0)))*abs.(M[1])))
+        return ApplyArray(\, M, Diagonal(sign.(view(M,band(0)))*abs(M[1])))
     # special case (Δa,Δb,Δc) = (0,0,-2)
     elseif iszero(Δa) && iszero(Δb) && (Δc == -2)
         M = qr(Q.t*I-Q.X).R
-        return ApplyArray(\, M, Diagonal(sign.(view(M,band(0)))*abs.(M[1])))
+        return ApplyArray(\, M, Diagonal(sign.(view(M,band(0)))*abs(M[1])))
     # special case (Δa,Δb,Δc) = (1,0,0)
     elseif isone(Δa) && iszero(Δb) && iszero(Δc)
         M = cholesky(P.X).U
-        return ApplyArray(*, Diagonal(Fill(1/M[1],∞)), M)
+        return M/M[1]
     # special case (Δa,Δb,Δc) = (0,1,0)
     elseif iszero(Δa) && isone(Δb) && iszero(Δc)
         M = cholesky(I-P.X).U
-        return ApplyArray(*, Diagonal(Fill(1/M[1],∞)), M)
+        return M/M[1]
     # special case (Δa,Δb,Δc) = (0,0,1)
     elseif iszero(Δa) && iszero(Δb) && isone(Δc)
         M = cholesky(Q.t*I-P.X).U

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,3 @@
+# The old ldiv variants are still supported for now but deprecated and implemented using non-efficient constructors
+Base.@deprecate semijacobi_ldiv_direct(Qt, Qa, Qb, Qc, P::SemiclassicalJacobi) semijacobi_ldiv_direct(SemiclassicalJacobi(Qt, Qa, Qb, Qc), P)
+Base.@deprecate semijacobi_ldiv(Qt, Qa, Qb, Qc, P::SemiclassicalJacobi) semijacobi_ldiv(SemiclassicalJacobi(Qt, Qa, Qb, Qc), P)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -619,24 +619,40 @@ end
     @test sprint(show, W) == "Weighted(SemiclassicalJacobi with weight x^2.3 * (1-x)^5.3 * (2.0-x)^0.4 on 0..1)"
 end
 
-@testset "basic lowering" begin
-    # lowering
-    t = 2.2
-    P = SemiclassicalJacobi(t, 2, 2, 2)
-    R_0 = SemiclassicalJacobi(t, 1, 2, 2) \ P
-    R_1 = SemiclassicalJacobi(t, 2, 1, 2) \ P
-    R_t = SemiclassicalJacobi(t, 2, 2, 1) \ P
+@testset "Lowering" begin
+    @testset "Decrements of 1 via Cholesky" begin
+        # Cholesky lowering
+        t = 2.2
+        P = SemiclassicalJacobi(t, 2, 2, 2)
+        R_0 = SemiclassicalJacobi(t, 1, 2, 2) \ P
+        R_1 = SemiclassicalJacobi(t, 2, 1, 2) \ P
+        R_t = SemiclassicalJacobi(t, 2, 2, 1) \ P
 
-    R_0inv = P \ SemiclassicalJacobi(t, 1, 2, 2)
-    R_1inv = P \ SemiclassicalJacobi(t, 2, 1, 2)
-    R_tinv = P \ SemiclassicalJacobi(t, 2, 2, 1)
+        R_0inv = P \ SemiclassicalJacobi(t, 1, 2, 2)
+        R_1inv = P \ SemiclassicalJacobi(t, 2, 1, 2)
+        R_tinv = P \ SemiclassicalJacobi(t, 2, 2, 1)
 
-    @test ApplyArray(inv,R_0inv)[1:20,1:20] ≈ R_0[1:20,1:20] 
-    @test ApplyArray(inv,R_1inv)[1:20,1:20] ≈ R_1[1:20,1:20] 
-    @test ApplyArray(inv,R_tinv)[1:20,1:20] ≈ R_t[1:20,1:20] 
+        @test ApplyArray(inv,R_0inv)[1:20,1:20] ≈ R_0[1:20,1:20] 
+        @test ApplyArray(inv,R_1inv)[1:20,1:20] ≈ R_1[1:20,1:20] 
+        @test ApplyArray(inv,R_tinv)[1:20,1:20] ≈ R_t[1:20,1:20] 
+    end
+    @testset "Decrements of 2 via QR" begin
+        # Cholesky lowering
+        t = 2.2
+        P = SemiclassicalJacobi(t, 3, 3, 3)
+        R_0 = SemiclassicalJacobi(t, 1, 3, 3) \ P
+        R_1 = SemiclassicalJacobi(t, 3, 1, 3) \ P
+        R_t = SemiclassicalJacobi(t, 3, 3, 1) \ P
+
+        R_0inv = P \ SemiclassicalJacobi(t, 1, 3, 3)
+        R_1inv = P \ SemiclassicalJacobi(t, 3, 1, 3)
+        R_tinv = P \ SemiclassicalJacobi(t, 3, 3, 1)
+
+        @test ApplyArray(inv,R_0inv)[1:20,1:20] ≈ R_0[1:20,1:20] 
+        @test ApplyArray(inv,R_1inv)[1:20,1:20] ≈ R_1[1:20,1:20] 
+        @test ApplyArray(inv,R_tinv)[1:20,1:20] ≈ R_t[1:20,1:20] 
+    end
 end
 
 include("test_derivative.jl")
 include("test_neg1c.jl")
-
-    

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -620,6 +620,25 @@ end
 end
 
 @testset "Lowering" begin
+    @testset "Constructing Lowered Polynomials" begin
+        t = 1.3184
+        P = SemiclassicalJacobi(t, 3, 3, 3)
+        Q_1 = SemiclassicalJacobi(t, 2, 3, 3, P)
+        Q_2 = SemiclassicalJacobi(t, 3, 3, 2, P)
+        Q_3 = SemiclassicalJacobi(t, 3, 2, 3, P)
+        Q_4 = SemiclassicalJacobi(t, 1, 2, 3, P)
+        Q_5 = SemiclassicalJacobi(t, 3, 2, 1, P)
+        Q_6 = SemiclassicalJacobi(t, 2, 2, 2, P)
+        Q_7 = SemiclassicalJacobi(t, 1, 1, 1, P)
+
+        @test Q_1.X[1:20,1:20] ≈ SemiclassicalJacobi(t, 2, 3, 3).X[1:20,1:20]
+        @test Q_2.X[1:20,1:20] ≈ SemiclassicalJacobi(t, 3, 3, 2).X[1:20,1:20]
+        @test Q_3.X[1:20,1:20] ≈ SemiclassicalJacobi(t, 3, 2, 3).X[1:20,1:20]
+        @test Q_4.X[1:20,1:20] ≈ SemiclassicalJacobi(t, 1, 2, 3).X[1:20,1:20]
+        @test Q_5.X[1:20,1:20] ≈ SemiclassicalJacobi(t, 3, 2, 1).X[1:20,1:20]
+        @test Q_6.X[1:20,1:20] ≈ SemiclassicalJacobi(t, 2, 2, 2).X[1:20,1:20] 
+        @test Q_7.X[1:20,1:20] ≈ SemiclassicalJacobi(t, 1, 1, 1).X[1:20,1:20] 
+    end
     @testset "Decrements of 1 via Cholesky" begin
         # Cholesky lowering
         t = 2.2
@@ -656,3 +675,4 @@ end
 
 include("test_derivative.jl")
 include("test_neg1c.jl")
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -619,5 +619,24 @@ end
     @test sprint(show, W) == "Weighted(SemiclassicalJacobi with weight x^2.3 * (1-x)^5.3 * (2.0-x)^0.4 on 0..1)"
 end
 
+@testset "basic lowering" begin
+    # lowering
+    t = 2.2
+    P = SemiclassicalJacobi(t, 2, 2, 2)
+    R_0 = SemiclassicalJacobi(t, 1, 2, 2) \ P
+    R_1 = SemiclassicalJacobi(t, 2, 1, 2) \ P
+    R_t = SemiclassicalJacobi(t, 2, 2, 1) \ P
+
+    R_0inv = P \ SemiclassicalJacobi(t, 1, 2, 2)
+    R_1inv = P \ SemiclassicalJacobi(t, 2, 1, 2)
+    R_tinv = P \ SemiclassicalJacobi(t, 2, 2, 1)
+
+    @test ApplyArray(inv,R_0inv)[1:20,1:20] ≈ R_0[1:20,1:20] 
+    @test ApplyArray(inv,R_1inv)[1:20,1:20] ≈ R_1[1:20,1:20] 
+    @test ApplyArray(inv,R_tinv)[1:20,1:20] ≈ R_t[1:20,1:20] 
+end
+
 include("test_derivative.jl")
 include("test_neg1c.jl")
+
+    


### PR DESCRIPTION
Not sure whether we will end up merging this or your PR @DanielVandH but the point of this is to show how a lowering implementation would look. It actually works already but it's not efficient.

```julia
julia> @testset "basic lowering" begin
           # lowering
           t = 2.2
           P = SemiclassicalJacobi(t, 2, 2, 2)
           R_0 = SemiclassicalJacobi(t, 1, 2, 2) \ P
           R_1 = SemiclassicalJacobi(t, 2, 1, 2) \ P
           R_t = SemiclassicalJacobi(t, 2, 2, 1) \ P

           R_0inv = P \ SemiclassicalJacobi(t, 1, 2, 2)
           R_1inv = P \ SemiclassicalJacobi(t, 2, 1, 2)
           R_tinv = P \ SemiclassicalJacobi(t, 2, 2, 1)

           @test ApplyArray(inv,R_0inv)[1:20,1:20] ≈ R_0[1:20,1:20]
           @test ApplyArray(inv,R_1inv)[1:20,1:20] ≈ R_1[1:20,1:20]
           @test ApplyArray(inv,R_tinv)[1:20,1:20] ≈ R_t[1:20,1:20]
       end
Test Summary:  | Pass  Total  Time
basic lowering |    3      3  0.0s
```

The reason for the inefficiency lies entirely with three lines where I 'cheat'. The iterative connection coefficients above are computed correctly, that's not the problem. The problem is in the computation we need `Q.X` which the user could either supply always (this would correspond to @dlfivefifty 's suggestion of changing all conventions to be an `semiclassical_ldiv(Q,X)` format or alternatively we can implement the reverse Cholesky Jacobi matrix which would go in the big marked by TODO section, i.e. this bit

```julia
 elseif isone(-Δa) && iszero(Δb) && iszero(Δc)  # raising by 1
        # TODO: This is re-constructing. It should instead use reverse Cholesky (or an alternative)!
        semiclassical_jacobimatrix(Q.t,a,b,c)
    elseif iszero(Δa) && isone(-Δb) && iszero(Δc)
        # TODO: This is re-constructing. It should instead use reverse Cholesky (or an alternative)!
        semiclassical_jacobimatrix(Q.t,a,b,c)
    elseif iszero(Δa) && iszero(Δb) && isone(-Δc)
        # TODO: This is re-constructing. It should instead use reverse Cholesky (or an alternative)!
        semiclassical_jacobimatrix(Q.t,a,b,c)
```

If the above was reverse Cholesky jacobimatrix then this PR would do everything you want I think. Without that, we have a design decision to make.