### PR TITLE
Implement weighted conversion between b=-1 polynomials

### DIFF
--- a/src/SemiclassicalOrthogonalPolynomials.jl
+++ b/src/SemiclassicalOrthogonalPolynomials.jl
@@ -465,6 +465,22 @@ function \(w_A::WeightedSemiclassicalJacobi{T}, w_B::WeightedSemiclassicalJacobi
         # k = (A \ SemiclassicalJacobiWeight(A.t,Δa,Δb,Δc))[1]
         k = sumquotient(SemiclassicalJacobiWeight(B.t,B.a,B.b,B.c),SemiclassicalJacobiWeight(A.t,A.a,A.b,A.c))
         return (ApplyArray(*,Diagonal(Fill(k,∞)),(B \ A)))'
+    elseif isone(-wA.b) && isone(-wB.b)
+        @assert A.a + 1 == B.a && A.c + 1 == B.c
+        Q = SemiclassicalJacobi(B.t, B.a, one(B.b), B.c, B)
+        P = SemiclassicalJacobi(A.t, A.a, one(A.b), A.c, A)
+        wP = Weighted(P) 
+        wQ = Weighted(Q)
+        R22 = wP \ wQ
+        r11 = A.t - 1 
+        qw0 = SemiclassicalJacobiWeight(Q.t, Q.a, zero(Q.b), Q.c)
+        pw0 = SemiclassicalJacobiWeight(P.t, P.a, zero(P.b), P.c)
+        r21 = wP[:, 1:2] \ (qw0 .- r11 .* pw0)
+        d0 = Vcat(r11, R22[band(0)])
+        d1 = Vcat(r21[begin], R22[band(-1)])
+        d2 = Vcat(r21[begin+1], R22[band(-2)])
+        data = Hcat(d0, d1, d2)
+        return _BandedMatrix(data', 1:∞, 2, 0)
     elseif wA.a == wB.a && wA.b == wB.b && wA.c == wB.c # fallback to Christoffel–Darboux
         A \ B
     elseif wA.a+1 == wB.a && wA.b == wB.b && wA.c == wB.c

--- a/src/SemiclassicalOrthogonalPolynomials.jl
+++ b/src/SemiclassicalOrthogonalPolynomials.jl
@@ -461,11 +461,8 @@ function \(w_A::WeightedSemiclassicalJacobi{T}, w_B::WeightedSemiclassicalJacobi
     Δb = B.b-A.b
     Δc = B.c-A.c
 
-    if (wA.a == A.a) && (wA.b == A.b) && (wA.c == A.c) && (wB.a == B.a) && (wB.b == B.b) && (wB.c == B.c) && isinteger(A.a) && isinteger(A.b) && isinteger(A.c) && isinteger(B.a) && isinteger(B.b) && isinteger(B.c)
-        # k = (A \ SemiclassicalJacobiWeight(A.t,Δa,Δb,Δc))[1]
-        k = sumquotient(SemiclassicalJacobiWeight(B.t,B.a,B.b,B.c),SemiclassicalJacobiWeight(A.t,A.a,A.b,A.c))
-        return (ApplyArray(*,Diagonal(Fill(k,∞)),(B \ A)))'
-    elseif isone(-wA.b) && isone(-wB.b)
+    # k = (A \ SemiclassicalJacobiWeight(A.t,Δa,Δb,Δc))[1]
+    if isone(-wA.b) && isone(-wB.b)
         @assert A.a + 1 == B.a && A.c + 1 == B.c
         Q = SemiclassicalJacobi(B.t, B.a, one(B.b), B.c, B)
         P = SemiclassicalJacobi(A.t, A.a, one(A.b), A.c, A)
@@ -481,6 +478,9 @@ function \(w_A::WeightedSemiclassicalJacobi{T}, w_B::WeightedSemiclassicalJacobi
         d2 = Vcat(r21[begin+1], R22[band(-2)])
         data = Hcat(d0, d1, d2)
         return _BandedMatrix(data', 1:∞, 2, 0)
+    elseif (wA.a == A.a) && (wA.b == A.b) && (wA.c == A.c) && (wB.a == B.a) && (wB.b == B.b) && (wB.c == B.c) && isinteger(A.a) && isinteger(A.b) && isinteger(A.c) && isinteger(B.a) && isinteger(B.b) && isinteger(B.c)
+            k = sumquotient(SemiclassicalJacobiWeight(B.t,B.a,B.b,B.c),SemiclassicalJacobiWeight(A.t,A.a,A.b,A.c))
+            return (ApplyArray(*,Diagonal(Fill(k,∞)),(B \ A)))'
     elseif wA.a == wB.a && wA.b == wB.b && wA.c == wB.c # fallback to Christoffel–Darboux
         A \ B
     elseif wA.a+1 == wB.a && wA.b == wB.b && wA.c == wB.c

--- a/test/test_neg1b.jl
+++ b/test/test_neg1b.jl
@@ -234,3 +234,17 @@ end
     @test_throws ArgumentError expand(HalfWeighted{:b}(P), g)
 end
 
+@testset "Weighted conversion between b=-1" begin
+    t, a, b, c = 2.0, 1 / 2, -1.0, 1 / 2
+    Q = SemiclassicalJacobi(t, a, b, c)
+    P = SemiclassicalJacobi(t, a - 1, b, c - 1)
+    L = Weighted(P) \ Weighted(Q)
+    wP = SemiclassicalJacobiWeight(t, a - 1, b, c - 1)
+    wQ = SemiclassicalJacobiWeight(t, a, b, c)
+    lhs = wQ .* Q
+    rhs = wP .* (P * L)
+    x = LinRange(eps(), 1 - eps(), 250)
+    lhs_vals = lhs[x, 1:20]
+    rhs_vals = rhs[x, 1:20]
+    @test lhs_vals ≈ rhs_vals
+end

--- a/test/test_neg1b.jl
+++ b/test/test_neg1b.jl
@@ -235,16 +235,17 @@ end
 end
 
 @testset "Weighted conversion between b=-1" begin
-    t, a, b, c = 2.0, 1 / 2, -1.0, 1 / 2
-    Q = SemiclassicalJacobi(t, a, b, c)
-    P = SemiclassicalJacobi(t, a - 1, b, c - 1)
-    L = Weighted(P) \ Weighted(Q)
-    wP = SemiclassicalJacobiWeight(t, a - 1, b, c - 1)
-    wQ = SemiclassicalJacobiWeight(t, a, b, c)
-    lhs = wQ .* Q
-    rhs = wP .* (P * L)
-    x = LinRange(eps(), 1 - eps(), 250)
-    lhs_vals = lhs[x, 1:20]
-    rhs_vals = rhs[x, 1:20]
-    @test lhs_vals ≈ rhs_vals
+    for (t, a, b, c) in ((2.0, 1 / 2, -1.0, 1 / 2), (2.5, 3 / 2, -1.0, 1 / 2), (2.5, 1.0, -1.0, 2.0))
+        Q = SemiclassicalJacobi(t, a, b, c)
+        P = SemiclassicalJacobi(t, a - 1, b, c - 1)
+        L = Weighted(P) \ Weighted(Q)
+        wP = SemiclassicalJacobiWeight(t, a - 1, b, c - 1)
+        wQ = SemiclassicalJacobiWeight(t, a, b, c)
+        lhs = wQ .* Q
+        rhs = wP .* (P * L)
+        x = LinRange(eps(), 1 - eps(), 250)
+        lhs_vals = lhs[x, 1:20]
+        rhs_vals = rhs[x, 1:20]
+        @test lhs_vals ≈ rhs_vals
+    end
 end


### PR DESCRIPTION
This computes the matrix $\mathbf R$ such that $w^{t, (a, -1, c)}\mathbf P^{t, (a, -1, c)} = w^{t, (a-1, -1, c-1)}\mathbf P^{t, (a-1, -1, c-1)}\mathbf R$. 

Explanation: The matrix $\mathbf R$ can be found by writing 
```math 
w^{t, (a, -1, c)}\begin{bmatrix} 1 & (1 - x)\mathbf P^{t, (a, 1, c)}\end{bmatrix} = w^{t, (a-1, -1, c-1)}\begin{bmatrix} 1 & (1-x)\mathbf P^{t, (a-1, 1, c-1)} \end{bmatrix}\begin{bmatrix} r_{11} & \mathbf 0^\top \\ \mathbf r_{21} & \mathbf R_{22} \end{bmatrix},
```
so that 
```math 
\begin{align*}
w^{t, (a, -1, c)} &= w^{t, (a-1, -1, c-1)}r_{11} + w^{t, (a-1, 0, c-1)}\mathbf P^{t, (a-1, 1, c-1)}\mathbf r_{21}, \\
w^{t, (a, 0, c)}\mathbf P^{t, (a, 1, c)} &= w^{t, (a-1, 0, c-1)}\mathbf P^{t, (a-1, 1, c-1)}\mathbf R_{22}.
\end{align*}
```
The second equation is just a weighted conversion (multiply by $1-x$ on both sides). For the first equation, we multiply by $1-x$ so that
```math 
w^{t, (a, 0, c)} = w^{t, (a-1, 0, c-1)}r_{11} + w^{t, (a-1, 1, c-1)}\mathbf P^{t, (a-1, 1, c-1)}\mathbf r_{21}.
```
To find $r_{11}$, plug in $x = 1$ which gives $r_{11} = t - 1$. Then,
```math 
w^{t, (a, 0, c)} - w^{t, (a-1, 0, c-1)}r_{11} = w^{t, (a-1, 1, c-1)}\mathbf P^{t, (a-1, 1, c-1)}\mathbf r_{21}.
```
Thus, $\mathbf r_{21}$ is the vector of expansion coefficients for the function $w^{t, (a, 0, c)} - w^{t, (a-1, 0, c-1)}r_{11}$ in the weighted basis $w^{t, (a-1, 1, c-1)}\mathbf P^{t, (a-1, 1, c-1)}$. Since $\mathbf R$ should be a $(2, 0)$ banded matrix, I only need to expand over the first two polynomials as the rest of the coefficients must be zero. Putting this all together gives the matrix.