### PR TITLE
Cholesky instead of Lanczos

### DIFF
--- a/src/SemiclassicalOrthogonalPolynomials.jl
+++ b/src/SemiclassicalOrthogonalPolynomials.jl
@@ -168,7 +168,7 @@ function semiclassical_jacobimatrix(t, a, b, c)
             return SemiclassicalJacobi.(t, a, b, 0:Int(c))[end].X
         else # if c is not an integer, use Lanczos
             x = axes(P,1)
-            return jacobimatrix(LanczosPolynomial(@.(x^a * (1-x)^b * (t-x)^c), jacobi(b, a, UnitInterval{T}())))
+            return cholesky_jacobimatrix(@.(x^a * (1-x)^b * (t-x)^c), P)
         end
     end
 end


### PR DESCRIPTION
Fixes https://github.com/JuliaApproximation/SemiclassicalOrthogonalPolynomials.jl/issues/130.
```julia
julia> n = 100; P = SemiclassicalJacobi(2, 1/2, 0, 1/2); @time P[0.1,n]
  0.064808 seconds (18.94 k allocations: 6.870 MiB)
-1.9278461993824534

julia> n = 200; P = SemiclassicalJacobi(2, 1/2, 0, 1/2); @time P[0.1,n]
  0.149148 seconds (38.25 k allocations: 14.203 MiB, 6.32% gc time)
-0.4280837544670504

julia> n = 400; P = SemiclassicalJacobi(2, 1/2, 0, 1/2); @time P[0.1,n]
  0.247942 seconds (76.85 k allocations: 29.288 MiB)
0.6259343524965154

julia> n = 800; P = SemiclassicalJacobi(2, 1/2, 0, 1/2); @time P[0.1,n]
  0.548767 seconds (180.02 k allocations: 62.887 MiB, 2.32% gc time)
0.9986605877062638
```

Speed is still very slow but at least its O(n).